### PR TITLE
Syfoutv 2511/feil i beregning av arbeidsgrad

### DIFF
--- a/web/src/frontend/js/components/sykepengesoknad-arbeidstaker/mappers/mapSkjemasoknadToBackendsoknad.js
+++ b/web/src/frontend/js/components/sykepengesoknad-arbeidstaker/mappers/mapSkjemasoknadToBackendsoknad.js
@@ -1,6 +1,7 @@
 import { fraInputdatoTilJSDato } from 'digisyfo-npm';
 import { visSoktOmSykepengerUtenlandsoppholdsporsmal } from '../FravaerOgFriskmelding/SoktOmSykepengerIUtenlandsopphold';
 import { getStillingsprosent } from '../AktiviteterISykmeldingsperioden/DetteTilsvarer';
+import { filtrerAktuelleAktiviteter } from '../../../utils/sykepengesoknadUtils';
 
 const parsePerioder = (perioder) => {
     return perioder.map((periode) => {
@@ -56,8 +57,10 @@ const tilInt = (streng) => {
     return parseFloat(streng.replace(',', '.'));
 };
 
-const getAktiviteter = (aktiviteter, ferieOgPermisjonPerioder) => {
-    return aktiviteter.map((aktivitet) => {
+const getAktiviteter = (aktiviteter, ferieOgPermisjonPerioder, gjenopptattDato) => {
+    const _aktiviteter = filtrerAktuelleAktiviteter(aktiviteter, gjenopptattDato);
+
+    return _aktiviteter.map((aktivitet) => {
         const _a = {
             periode: aktivitet.periode,
             grad: aktivitet.grad,
@@ -112,6 +115,7 @@ const mapSkjemasoknadToBackendsoknad = (soknad, alternativer = {}) => {
     const permisjonperioder = parsePerioder(permisjon);
     const ferieperioder = parsePerioder(ferie);
     const ferieOgPermisjonPerioder = [...ferieperioder, ...permisjonperioder];
+    const gjenopptattArbeidFulltUtDato = soknad.harGjenopptattArbeidFulltUt ? fraInputdatoTilJSDato(soknad.gjenopptattArbeidFulltUtDato) : null;
 
     const backendSoknad = {
         ...soknad,
@@ -119,9 +123,9 @@ const mapSkjemasoknadToBackendsoknad = (soknad, alternativer = {}) => {
         ferie: ferieperioder,
         utenlandsopphold,
         andreInntektskilder: parseInntektskilder(soknad.andreInntektskilder),
-        gjenopptattArbeidFulltUtDato: soknad.harGjenopptattArbeidFulltUt ? fraInputdatoTilJSDato(soknad.gjenopptattArbeidFulltUtDato) : null,
+        gjenopptattArbeidFulltUtDato,
         egenmeldingsperioder: soknad.bruktEgenmeldingsdagerFoerLegemeldtFravaer ? parsePerioder(soknad.egenmeldingsperioder) : [],
-        aktiviteter: getAktiviteter(soknad.aktiviteter, ferieOgPermisjonPerioder),
+        aktiviteter: getAktiviteter(soknad.aktiviteter, ferieOgPermisjonPerioder, gjenopptattArbeidFulltUtDato),
         utdanning: getUtdanning(soknad.utdanning),
     };
 

--- a/web/src/frontend/localserver.js
+++ b/web/src/frontend/localserver.js
@@ -234,6 +234,12 @@ const startServer = (html) => {
         res.send(JSON.stringify({}));
     });
 
+    server.get('/http://localhost:8080/syforest/informasjon/arbeidsgivere?sykmeldingId=:uuid', (req, res) => {
+        res.send(JSON.stringify({}));
+    });
+
+
+
 // END - MOCKS
     server.listen(8080, () => {
         console.log('App listening on port: 8080');

--- a/web/src/frontend/test/utils/mapSkjemasoknadToBackendsoknadTest.js
+++ b/web/src/frontend/test/utils/mapSkjemasoknadToBackendsoknadTest.js
@@ -452,5 +452,35 @@ describe('mapSkjemasoknadToBackendsoknad', () => {
                 arbeidstimerNormalUke: 12.5,
             });
         });
+
+        it('kutter aktivitet og beregner riktig arbeidsgrad ved gjenopptattdato', () => {
+            const aktiviteter = [
+                {
+                    periode: {
+                        fom: new Date('2018-10-01'),
+                        tom: new Date('2018-10-10'),
+                    },
+                    grad: 100,
+                    avvik: {
+                        enhet: 'timer',
+                        timer: '5',
+                        arbeidstimerNormalUke: '40',
+                    },
+                    jobbetMerEnnPlanlagt: true,
+                },
+            ];
+
+            const _soknad = mapSkjemasoknadToBackendsoknad(deepFreeze(Object.assign({}, soknad, {
+                aktiviteter,
+                harGjenopptattArbeidFulltUt: true,
+                gjenopptattArbeidFulltUtDato: '09.10.2018',
+            })));
+
+            expect(_soknad.aktiviteter[0].avvik).to.deep.equal({
+                beregnetArbeidsgrad: 10,
+                arbeidstimerNormalUke: 40,
+                timer: 5,
+            });
+        });
     });
 });


### PR DESCRIPTION
Vi må justere periodene før vi beregner arbeidsgrad

SYFOUTV-2511
Dette fikser en feil der beregnet arbeidsgrad blir ikke tar hensyn til når arbeidet ble gjenopptatt. Bruker og arbeidsgiver vil få riktig verdi, men det blir feil beregner i gosys. Dette har på ingen måte tilbakevirkende effekt.