### PR TITLE
Ruter nå til /soknader når bruker avbryter en søknad som slettes

### DIFF
--- a/js/reducers/soknader.js
+++ b/js/reducers/soknader.js
@@ -22,7 +22,7 @@ import {
     SOKNAD_GJENAPNET,
 } from '../actions/actiontyper';
 import { DATO, PERIODER, PROSENT, TIMER } from '../enums/svartyper';
-import { SENDT, NY, AVBRUTT } from '../enums/soknadstatuser';
+import { SENDT, NY, AVBRUTT, UTKAST_TIL_KORRIGERING } from '../enums/soknadstatuser';
 import { OPPHOLD_UTLAND } from '../enums/soknadtyper';
 
 const initiellState = {
@@ -157,7 +157,7 @@ export default (state = initiellState, action = {}) => {
             };
         }
         case SOKNAD_AVBRUTT: {
-            const data = action.soknad.soknadstype === OPPHOLD_UTLAND
+            const data = action.soknad.soknadstype === OPPHOLD_UTLAND || action.soknad.status === UTKAST_TIL_KORRIGERING
                 ? [...state.data.filter((s) => {
                     return s.id !== action.soknad.id;
                 })]

--- a/js/sagas/soknaderSagas.js
+++ b/js/sagas/soknaderSagas.js
@@ -25,6 +25,7 @@ import fraBackendsoknadTilInitiellSoknad from '../utils/soknad-felles/fraBackend
 import { hentSkjemaVerdier } from '../selectors/reduxFormSelectors';
 import { getSkjemanavnFraSoknad } from '../utils/soknad-felles/getSkjemanavnFraSoknad';
 import getContextRoot from '../utils/getContextRoot';
+import { UTKAST_TIL_KORRIGERING } from '../enums/soknadstatuser';
 
 const gaTilKvittering = (soknadId) => {
     browserHistory.push(`/sykefravaer/soknader/${soknadId}/kvittering`);
@@ -78,8 +79,8 @@ export function* avbrytSoknad(action) {
             yield put(actions.avbryterSoknad());
             yield call(post, `${hentApiUrl()}/soknader/${action.soknad.id}/avbryt`);
             yield put(actions.soknadAvbrutt(action.soknad));
-            if (action.soknad.soknadstype === OPPHOLD_UTLAND) {
-                browserHistory.push(getContextRoot());
+            if (action.soknad.soknadstype === OPPHOLD_UTLAND || action.soknad.status === UTKAST_TIL_KORRIGERING) {
+                browserHistory.push(`${getContextRoot()}/soknader`);
             }
         } catch (e) {
             log(e);

--- a/mockEndepunkter.js
+++ b/mockEndepunkter.js
@@ -107,7 +107,7 @@ function mockEndepunkterSomEndrerState(server) {
 
     server.post('/syfoapi/syfosoknad/api/avbrytSoknad', (req, res) => {
         const soknad = req.body;
-        if (soknad.soknadstype === 'OPPHOLD_UTLAND') {
+        if (soknad.soknadstype === 'OPPHOLD_UTLAND' || soknad.status === 'UTKAST_TIL_KORRIGERING') {
             mockData.soknader = mockData.soknader.filter((s) => {
                 return s.id !== soknad.id;
             });
@@ -192,6 +192,11 @@ function mockEndepunkterSomEndrerState(server) {
         res.setHeader('Content-Type', 'application/json');
         res.send(JSON.stringify(utkast));
     });
+
+    server.post('/syfoapi/syfosoknad/api/soknader/:id/avbryt', (req, res) => {
+        mockData.soknader = mockData.soknader.filter(soknad => soknad.id !== req.params.id);
+        res.send(JSON.stringify({}));
+    })
 }
 
 function mockForOpplaeringsmiljo(server) {

--- a/test/reducers/soknaderTest.js
+++ b/test/reducers/soknaderTest.js
@@ -6,8 +6,8 @@ import * as actions from '../../js/actions/soknader_actions';
 import mockSoknader, { getSoknad, soknadrespons } from '../mockSoknader';
 import { ANSVARSERKLARING } from '../../js/enums/tagtyper';
 import { bekreftSykmeldingAngret } from '../../js/actions/dinSykmelding_actions';
-import { AVBRUTT, NY, SENDT, FREMTIDIG } from '../../js/enums/soknadstatuser';
-import { OPPHOLD_UTLAND } from '../../js/enums/soknadtyper';
+import { AVBRUTT, NY, SENDT, FREMTIDIG, UTKAST_TIL_KORRIGERING } from '../../js/enums/soknadstatuser';
+import { OPPHOLD_UTLAND, SELVSTENDIGE_OG_FRILANSERE } from '../../js/enums/soknadtyper';
 
 describe('soknader', () => {
     let getStateMedDataHentet;
@@ -105,6 +105,22 @@ describe('soknader', () => {
     it('Håndterer soknadAvbrutt når søknaden som avbrytes er en utenlandsopphold-søknad', () => {
         const initState = getStateMedDataHentet();
         initState.data[0].soknadstype = OPPHOLD_UTLAND;
+
+        const avbryterAction = actions.avbryterSoknad();
+        let nyState = soknader(deepFreeze(initState), avbryterAction);
+
+        const avbruttAction = actions.soknadAvbrutt(nyState.data[0]);
+        nyState = soknader(deepFreeze(nyState), avbruttAction);
+
+        expect(nyState.data).to.deep.equal([]);
+        expect(nyState.avbryter).to.equal(false);
+        expect(nyState.avbrytSoknadFeilet).to.equal(false);
+    });
+
+    it('Håndterer soknadAvbrutt når søknaden som avbrytes er et utkast til korrigering', () => {
+        const initState = getStateMedDataHentet();
+        initState.data[0].soknadstype = SELVSTENDIGE_OG_FRILANSERE;
+        initState.data[0].status = UTKAST_TIL_KORRIGERING;
 
         const avbryterAction = actions.avbryterSoknad();
         let nyState = soknader(deepFreeze(initState), avbryterAction);


### PR DESCRIPTION
SYFOUTV-2559
Det gjelder utenlandsopphold og utkast til korrigering. Fikset også mockendepunkt for avbryt.