### PR TITLE
Endrer urlene vi matcher på slik at serveren korrekt serverer 404

### DIFF
--- a/server.js
+++ b/server.js
@@ -66,7 +66,7 @@ const startServer = (html) => {
     );
 
     server.get(
-        ['/', '/sykefravaer/?', /^\/sykefravaer\/(?!.*dist).*$/],
+        ['/', '/sykefravaer/?', /^\/sykefravaer\/(?!(resources|img)).*$/],
         (req, res) => {
             res.send(html);
             httpRequestDurationMicroseconds


### PR DESCRIPTION
Det ser ikke ut som vi noen ganger server noe bak `/dist/` så det har jeg bare fjernet.

Nå vil kall til `resources` eller `img` som ikke treffer nøyaktig på en fil i `dist/resources/*` gi en hard 404 🎉 
