### PR TITLE
Viser infotekst hvis henting av sm-sykmeldinger feiler

### DIFF
--- a/js/sykmeldinger/sider/sykmeldinger-side/SykmeldingerSide.js
+++ b/js/sykmeldinger/sider/sykmeldinger-side/SykmeldingerSide.js
@@ -1,3 +1,4 @@
+/* eslint arrow-body-style: ["error", "as-needed"] */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -29,7 +30,7 @@ export class Container extends Component {
     }
 
     render() {
-        const { brodsmuler, sykmeldinger, henter, hentingFeilet, sortering, smSykmeldinger } = this.props;
+        const { brodsmuler, sykmeldinger, henter, hentingFeilet, hentingSmFeilet, sortering, smSykmeldinger } = this.props;
         return (<Side tittel={getLedetekst('dine-sykmeldinger.sidetittel')} brodsmuler={brodsmuler} laster={henter}>
             {
                 (() => {
@@ -38,10 +39,14 @@ export class Container extends Component {
                     } else if (hentingFeilet) {
                         return (<Feilmelding />);
                     }
-                    return (<Sykmeldinger
-                        smSykmeldinger={smSykmeldinger}
-                        sykmeldinger={sykmeldinger}
-                        sortering={sortering} />);
+                    return (
+                        <Sykmeldinger
+                            smSykmeldinger={smSykmeldinger}
+                            sykmeldinger={sykmeldinger}
+                            sortering={sortering}
+                            infomelding={hentingSmFeilet ? 'Det skjedde en feil ved henting av sykmeldinger, kan ikke vise alle sykmeldinger' : null}
+                        />
+                    );
                 })()
             }
         </Side>);
@@ -53,6 +58,7 @@ Container.propTypes = {
     sykmeldinger: PropTypes.arrayOf(sykmeldingPt),
     henter: PropTypes.bool,
     hentingFeilet: PropTypes.bool,
+    hentingSmFeilet: PropTypes.bool,
     sortering: PropTypes.shape({
         tidligere: PropTypes.string,
     }),
@@ -68,7 +74,8 @@ export function mapStateToProps(state) {
         smSykmeldinger: avvisteSmSykmeldingerDataSelector(state),
         sortering: state.dineSykmeldinger.sortering,
         henter: state.ledetekster.henter || state.dineSykmeldinger.henter || !state.dineSykmeldinger.hentet || henterSmSykmeldingerSelector(state),
-        hentingFeilet: state.ledetekster.hentingFeilet || state.dineSykmeldinger.hentingFeilet || hentingFeiletSmSykmeldingerSelector(state),
+        hentingFeilet: state.ledetekster.hentingFeilet || state.dineSykmeldinger.hentingFeilet,
+        hentingSmFeilet: hentingFeiletSmSykmeldingerSelector(state),
         skalHenteSmSykmeldinger: skalHenteSmSykmeldingerSelector(state),
         brodsmuler: [{
             tittel: getLedetekst('landingsside.sidetittel'),

--- a/js/sykmeldinger/sykmeldinger/Sykmeldinger.js
+++ b/js/sykmeldinger/sykmeldinger/Sykmeldinger.js
@@ -1,47 +1,47 @@
+/* eslint arrow-body-style: ["error", "as-needed"] */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getLedetekst, getHtmlLedetekst, sorterSykmeldinger, sorterSykmeldingerEldsteFoerst, sykmeldingstatuser } from '@navikt/digisyfo-npm';
+import AlertStripeInfo from 'nav-frontend-alertstriper';
+import { getHtmlLedetekst, getLedetekst, sorterSykmeldinger, sorterSykmeldingerEldsteFoerst, sykmeldingstatuser } from '@navikt/digisyfo-npm';
 import SykmeldingTeasere from './SykmeldingTeasere';
 import SykmeldingerSorteringContainer from './SykmeldingerSorteringContainer';
 import Sidetopp from '../../components/Sidetopp';
 import { sykmelding as sykmeldingPt } from '../../propTypes';
 import { smSykmeldingerPt } from '../../propTypes/smSykmeldingProptypes';
 
-const Sykmeldinger = ({ sykmeldinger = [], sortering, smSykmeldinger }) => {
-    const nyeSykmeldinger = sykmeldinger.filter((sykmld) => {
-        return sykmld.status === sykmeldingstatuser.NY;
-    });
-    const tidligereSykmeldinger = sykmeldinger.filter((sykmld) => {
-        return sykmld.status !== sykmeldingstatuser.NY;
-    });
+const Sykmeldinger = ({ sykmeldinger = [], sortering, smSykmeldinger, infomelding = null }) => {
+    const nyeSykmeldinger = sykmeldinger.filter(sykmld => sykmld.status === sykmeldingstatuser.NY);
+    const tidligereSykmeldinger = sykmeldinger.filter(sykmld => sykmld.status !== sykmeldingstatuser.NY);
     const tidligereSortering = sortering && sortering.tidligere ? sortering.tidligere : undefined;
-    const ulesteSmSykmeldinger = smSykmeldinger.filter((smSykmelding) => {
-        return smSykmelding.bekreftetDato === null;
-    });
-    const lesteSmSykmeldinger = smSykmeldinger.filter((smSykmelding) => {
-        return smSykmelding.bekreftetDato !== null;
-    });
-    return (<div>
-        <Sidetopp
-            tittel={getLedetekst('dine-sykmeldinger.tittel')}
-            htmlTekst={getHtmlLedetekst('dine-sykmeldinger.introduksjonstekst')}
-        />
-        <SykmeldingTeasere
-            sykmeldinger={sorterSykmeldingerEldsteFoerst([...nyeSykmeldinger, ...ulesteSmSykmeldinger])}
-            tittel={getLedetekst('dine-sykmeldinger.nye-sykmeldinger.tittel')}
-            ingenSykmeldingerMelding={getLedetekst('dine-sykmeldinger.nye-sykmeldinger.ingen-sykmeldinger.melding')}
-            className="js-nye-sykmeldinger"
-            id="sykmelding-liste-nye" />
-        {
-            (tidligereSykmeldinger.length > 0 || lesteSmSykmeldinger.length > 0) && <SykmeldingTeasere
-                sykmeldinger={sorterSykmeldinger([...tidligereSykmeldinger, ...lesteSmSykmeldinger], tidligereSortering)}
-                tittel={getLedetekst('dine-sykmeldinger.tidligere-sykmeldinger.tittel')}
-                className="js-tidligere-sykmeldinger"
-                id="sykmelding-liste-tidligere">
-                <SykmeldingerSorteringContainer status="tidligere" />
-            </SykmeldingTeasere>
-        }
-    </div>);
+    const ulesteSmSykmeldinger = smSykmeldinger.filter(smSykmelding => smSykmelding.bekreftetDato === null);
+    const lesteSmSykmeldinger = smSykmeldinger.filter(smSykmelding => smSykmelding.bekreftetDato !== null);
+    return (
+        <React.Fragment>
+            <Sidetopp
+                tittel={getLedetekst('dine-sykmeldinger.tittel')}
+                htmlTekst={getHtmlLedetekst('dine-sykmeldinger.introduksjonstekst')}
+            />
+            {infomelding !== null && <AlertStripeInfo type={'info'} className={'blokk-m'}>{infomelding}</AlertStripeInfo>}
+            <SykmeldingTeasere
+                sykmeldinger={sorterSykmeldingerEldsteFoerst([...nyeSykmeldinger, ...ulesteSmSykmeldinger])}
+                tittel={getLedetekst('dine-sykmeldinger.nye-sykmeldinger.tittel')}
+                ingenSykmeldingerMelding={getLedetekst('dine-sykmeldinger.nye-sykmeldinger.ingen-sykmeldinger.melding')}
+                className="js-nye-sykmeldinger"
+                id="sykmelding-liste-nye"
+            />
+            {
+                (tidligereSykmeldinger.length > 0 || lesteSmSykmeldinger.length > 0) &&
+                <SykmeldingTeasere
+                    sykmeldinger={sorterSykmeldinger([...tidligereSykmeldinger, ...lesteSmSykmeldinger], tidligereSortering)}
+                    tittel={getLedetekst('dine-sykmeldinger.tidligere-sykmeldinger.tittel')}
+                    className="js-tidligere-sykmeldinger"
+                    id="sykmelding-liste-tidligere"
+                >
+                    <SykmeldingerSorteringContainer status="tidligere" />
+                </SykmeldingTeasere>
+            }
+        </React.Fragment>
+    );
 };
 
 Sykmeldinger.propTypes = {
@@ -50,6 +50,7 @@ Sykmeldinger.propTypes = {
         tidligere: PropTypes.string,
     }),
     smSykmeldinger: smSykmeldingerPt,
+    infomelding: PropTypes.string,
 };
 
 export default Sykmeldinger;


### PR DESCRIPTION
Istedet for a feile hardt vises en infomelding som sier at noen sykmedlinger ikke vises.

![image](https://user-images.githubusercontent.com/3852471/60523652-5f33f900-9ceb-11e9-8eb0-55169ade8756.png)
