### PR TITLE
Fikser en at klikking på avbryt sykmelding ikke virket lenger

### DIFF
--- a/js/sykmeldinger/sykmelding-ny/sykmelding-skjema/skjema/DinSykmeldingSkjema.js
+++ b/js/sykmeldinger/sykmelding-ny/sykmelding-skjema/skjema/DinSykmeldingSkjema.js
@@ -134,8 +134,9 @@ export class DinSykmeldingSkjemaComponent extends Component {
             handleSubmit,
             visFrilansersporsmal,
             untouch,
-            visAvbrytDialog,
         } = this.props;
+
+        const { visAvbrytDialog } = this.state;
 
         return (
             <form
@@ -311,7 +312,6 @@ export const mapStateToProps = (state, ownProps) => {
         sendingFeilet: state.dineSykmeldinger.sendingFeilet,
         avbryter: state.dineSykmeldinger.avbryter,
         avbrytFeilet: state.dineSykmeldinger.avbrytFeilet,
-        visAvbrytDialog: state.visAvbrytDialog,
     };
 };
 


### PR DESCRIPTION
I en refaktorering ble redux-state og component-state mikset opp. Det brakk komponenten.