### PR TITLE
Ikke motebehov hvis moteplanlegger brukt

### DIFF
--- a/js/components/moter/DialogmoterInnhold.js
+++ b/js/components/moter/DialogmoterInnhold.js
@@ -1,17 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getLedetekst } from '@navikt/digisyfo-npm';
-import { motebehovReducerPt } from '../../propTypes';
 import Sidetopp from '../Sidetopp';
 import DialogmoterInnholdLenke from './DialogmoterInnholdLenke';
 import MotebehovInnholdLenke from './MotebehovInnholdLenke';
 
 const DialogmoterInnhold = (
     {
-        motebehovReducer,
         harMote,
+        skalViseKvittering,
         skalViseMotebehov,
-        virksomhetnrMedMotebehovListe,
     },
 ) => {
     return (
@@ -21,8 +19,7 @@ const DialogmoterInnhold = (
             { skalViseMotebehov
         && (
             <MotebehovInnholdLenke
-                motebehovReducer={motebehovReducer}
-                virksomhetsnrListe={virksomhetnrMedMotebehovListe}
+                skalViseKvittering={skalViseKvittering}
             />
         )
             }
@@ -32,10 +29,9 @@ const DialogmoterInnhold = (
     );
 };
 DialogmoterInnhold.propTypes = {
-    motebehovReducer: motebehovReducerPt,
     harMote: PropTypes.bool,
+    skalViseKvittering: PropTypes.bool,
     skalViseMotebehov: PropTypes.bool,
-    virksomhetnrMedMotebehovListe: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default DialogmoterInnhold;

--- a/js/components/moter/MotebehovInnhold.js
+++ b/js/components/moter/MotebehovInnhold.js
@@ -4,12 +4,13 @@ import { getLedetekst } from '@navikt/digisyfo-npm';
 import {
     motebehovReducerPt,
     motebehovSvarReducerPt,
+    sykeforloepPt,
 } from '../../propTypes';
 import Sidetopp from '../Sidetopp';
 import MotebehovSvar from './motebehov/MotebehovSvar';
 import MotebehovKvittering from './motebehov/MotebehovKvittering';
 import {
-    finnNyesteMotebehovForVirksomhetListe,
+    finnNyesteMotebehovForVirksomhetListeIOppfolgingstilfelle,
 } from '../../utils/motebehovUtils';
 
 const MotebehovInnhold = (
@@ -17,10 +18,11 @@ const MotebehovInnhold = (
         actions,
         motebehovReducer,
         motebehovSvarReducerListe,
+        oppfolgingsforlopsPerioderReducerListe,
         virksomhetnrMedMotebehovListe,
     },
 ) => {
-    const motebehov = finnNyesteMotebehovForVirksomhetListe(motebehovReducer, virksomhetnrMedMotebehovListe);
+    const motebehov = finnNyesteMotebehovForVirksomhetListeIOppfolgingstilfelle(motebehovReducer, virksomhetnrMedMotebehovListe, oppfolgingsforlopsPerioderReducerListe);
 
     const innhold = motebehov
         ? (
@@ -50,6 +52,7 @@ MotebehovInnhold.propTypes = {
     }),
     motebehovReducer: motebehovReducerPt,
     motebehovSvarReducerListe: PropTypes.arrayOf(motebehovSvarReducerPt),
+    oppfolgingsforlopsPerioderReducerListe: PropTypes.arrayOf(sykeforloepPt),
     virksomhetnrMedMotebehovListe: PropTypes.arrayOf(PropTypes.string),
 };
 

--- a/js/components/moter/MotebehovInnholdLenke.js
+++ b/js/components/moter/MotebehovInnholdLenke.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { getLedetekst } from '@navikt/digisyfo-npm';
-import { motebehovReducerPt } from '../../propTypes';
-import { skalViseMotebehovKvittering } from '../../utils/motebehovUtils';
 
 const TEKSTER = {
     tittel: 'Ønsker du et dialogmøte med NAV?',
@@ -12,11 +10,10 @@ const TEKSTER = {
 
 const MotebehovInnholdLenke = (
     {
-        motebehovReducer,
-        virksomhetsnrListe,
+        skalViseKvittering,
     },
 ) => {
-    const knappTekstNokkel = skalViseMotebehovKvittering(motebehovReducer, virksomhetsnrListe)
+    const knappTekstNokkel = skalViseKvittering
         ? 'mote.motebehovInnholdLenke.knapp.kvittering'
         : 'mote.motebehovInnholdLenke.knapp.svar';
     return (
@@ -33,8 +30,7 @@ const MotebehovInnholdLenke = (
     );
 };
 MotebehovInnholdLenke.propTypes = {
-    motebehovReducer: motebehovReducerPt,
-    virksomhetsnrListe: PropTypes.arrayOf(PropTypes.string),
+    skalViseKvittering: PropTypes.bool,
 };
 
 export default MotebehovInnholdLenke;

--- a/js/landingsside/sider/LandingssideSide.js
+++ b/js/landingsside/sider/LandingssideSide.js
@@ -205,7 +205,7 @@ export function mapStateToProps(state) {
         harSykmeldinger: state.dineSykmeldinger.data.length > 0 || avvisteSmSykmeldingerDataSelector(state).length > 0,
         skalViseMotebehov: !state.dineSykmeldinger.hentingFeilet
             && !state.ledere.hentingFeilet
-            && skalViseMotebehovMedOppfolgingsforlopListe(oppfolgingsforlopsPerioderReducerListe, state.motebehov),
+            && skalViseMotebehovMedOppfolgingsforlopListe(oppfolgingsforlopsPerioderReducerListe, state.motebehov, state.mote),
         skalViseOppfolgingsdialog: !state.dineSykmeldinger.hentingFeilet
             && !state.oppfolgingsdialoger.hentingFeilet
             && !state.ledere.hentingFeilet

--- a/js/sider/DialogmoterSide.js
+++ b/js/sider/DialogmoterSide.js
@@ -151,7 +151,7 @@ export function mapStateToProps(state) {
     const virksomhetsnrListe = finnVirksomheterMedAktivSykmelding(dineSykmeldingerReducer.data, ledereReducer.data);
     const oppfolgingsforlopsPerioderReducerListe = finnOppfolgingsforlopsPerioderForAktiveSykmeldinger(state, virksomhetsnrListe);
     const virksomhetnrMedMotebehovListe = finnVirksomhetnrListeMedSkalViseMotebehov(oppfolgingsforlopsPerioderReducerListe);
-    const skalViseMotebehov = skalViseMotebehovMedOppfolgingsforlopListe(oppfolgingsforlopsPerioderReducerListe, motebehovReducer);
+    const skalViseMotebehov = skalViseMotebehovMedOppfolgingsforlopListe(oppfolgingsforlopsPerioderReducerListe, motebehovReducer, moteReducer);
 
     const skalHenteLedere = !henterEllerHarHentetLedere(ledereReducer);
 

--- a/js/sider/DialogmoterSide.js
+++ b/js/sider/DialogmoterSide.js
@@ -22,7 +22,11 @@ import {
     henterEllerHarHentetLedere,
 } from '../utils/reducerUtils';
 import { getMote } from '../utils/moteUtils';
-import { finnVirksomhetnrListeMedSkalViseMotebehov, skalViseMotebehovMedOppfolgingsforlopListe } from '../utils/motebehovUtils';
+import {
+    finnVirksomhetnrListeMedSkalViseMotebehov,
+    skalViseMotebehovKvittering,
+    skalViseMotebehovMedOppfolgingsforlopListe,
+} from '../utils/motebehovUtils';
 import {
     finnOgHentManglendeOppfolgingsforlopsPerioder,
     finnOppfolgingsforlopsPerioderForAktiveSykmeldinger,
@@ -113,6 +117,7 @@ Container.propTypes = {
     harMote: PropTypes.bool,
     harForsoektHentetAlt: PropTypes.bool,
     skalHenteLedere: PropTypes.bool,
+    skalViseKvittering: PropTypes.bool,
     skalViseMotebehov: PropTypes.bool,
     virksomhetsnrListe: PropTypes.arrayOf(PropTypes.string),
     virksomhetnrMedMotebehovListe: PropTypes.arrayOf(PropTypes.string),
@@ -152,6 +157,7 @@ export function mapStateToProps(state) {
     const oppfolgingsforlopsPerioderReducerListe = finnOppfolgingsforlopsPerioderForAktiveSykmeldinger(state, virksomhetsnrListe);
     const virksomhetnrMedMotebehovListe = finnVirksomhetnrListeMedSkalViseMotebehov(oppfolgingsforlopsPerioderReducerListe);
     const skalViseMotebehov = skalViseMotebehovMedOppfolgingsforlopListe(oppfolgingsforlopsPerioderReducerListe, motebehovReducer, moteReducer);
+    const skalViseKvittering = skalViseMotebehovKvittering(motebehovReducer, virksomhetsnrListe, oppfolgingsforlopsPerioderReducerListe);
 
     const skalHenteLedere = !henterEllerHarHentetLedere(ledereReducer);
 
@@ -177,6 +183,7 @@ export function mapStateToProps(state) {
         harMote,
         harForsoektHentetAlt,
         skalHenteLedere,
+        skalViseKvittering,
         skalViseMotebehov,
         virksomhetsnrListe,
         virksomhetnrMedMotebehovListe,

--- a/js/sider/MotebehovSide.js
+++ b/js/sider/MotebehovSide.js
@@ -14,7 +14,11 @@ import {
 } from '../utils/reducerUtils';
 import { hentDineSykmeldinger } from '../sykmeldinger/data/dine-sykmeldinger/dineSykmeldingerActions';
 import { hentLedere } from '../landingsside/data/ledere/ledereActions';
-import { hentMotebehov, svarMotebehov } from '../data/motebehov/motebehov_actions';
+import { hentMote } from '../data/moter/mote_actions';
+import {
+    hentMotebehov,
+    svarMotebehov,
+} from '../data/motebehov/motebehov_actions';
 import { hentOppfolgingsforlopsPerioder } from '../data/oppfolgingsforlopsperioder/oppfolgingsforlopsPerioder_actions';
 import {
     finnOgHentManglendeOppfolgingsforlopsPerioder,
@@ -24,7 +28,11 @@ import {
     henterEllerHarForsoektHentetOppfolgingsPerioder,
     hentOppfolgingsPerioderFeilet,
 } from '../utils/oppfolgingsforlopsperioderUtils';
-import { finnVirksomhetnrListeMedSkalViseMotebehov, harSvarMotebehovFeilet, skalViseMotebehovMedOppfolgingsforlopListe } from '../utils/motebehovUtils';
+import {
+    finnVirksomhetnrListeMedSkalViseMotebehov,
+    harSvarMotebehovFeilet,
+    skalViseMotebehovMedOppfolgingsforlopListe,
+} from '../utils/motebehovUtils';
 import { selectLedeteksterData } from '../data/ledetekster/ledeteksterSelectors';
 
 class Container extends Component {
@@ -38,6 +46,7 @@ class Container extends Component {
 
         actions.hentDineSykmeldinger();
         actions.hentMotebehov();
+        actions.hentMote();
         finnOgHentManglendeOppfolgingsforlopsPerioder(actions.hentOppfolgingsforlopsPerioder, oppfolgingsforlopsPerioderReducerListe, virksomhetsnrListe);
 
         if (skalHenteLedere) {
@@ -67,14 +76,17 @@ class Container extends Component {
                     (() => {
                         if (henter) {
                             return <AppSpinner />;
-                        } if (hentingFeilet || sendingFeilet || !skalViseMotebehov) {
+                        } else if (hentingFeilet || sendingFeilet) {
                             return <Feilmelding />;
+                        } else if (!skalViseMotebehov) {
+                            return (<Feilmelding
+                                tittel={'Møtebehovsiden er ikke tilgjengelig nå.'}
+                                melding={'Dette kan være fordi veilederen din allerede har forespurt et møte, hvis ikke, prøv igjen senere.'}
+                            />);
                         }
-                        return (
-                            <MotebehovInnhold
-                                {...this.props}
-                            />
-                        );
+                        return (<MotebehovInnhold
+                            {...this.props}
+                        />);
                     })()
                 }
             </Side>
@@ -98,6 +110,7 @@ Container.propTypes = {
     actions: PropTypes.shape({
         hentDineSykmeldinger: PropTypes.func,
         hentLedere: PropTypes.func,
+        hentMote: PropTypes.func,
         hentMotebehov: PropTypes.func,
         svarMotebehov: PropTypes.func,
         hentOppfolgingsforlopsPerioder: PropTypes.func,
@@ -108,6 +121,7 @@ export function mapDispatchToProps(dispatch) {
     const actions = bindActionCreators({
         hentDineSykmeldinger,
         hentLedere,
+        hentMote,
         hentMotebehov,
         svarMotebehov,
         hentOppfolgingsforlopsPerioder,
@@ -122,6 +136,7 @@ export function mapStateToProps(state) {
     const ledereReducer = state.ledere;
     const dineSykmeldingerReducer = state.dineSykmeldinger;
     const motebehovReducer = state.motebehov;
+    const moteReducer = state.mote;
 
     const virksomhetsnrListe = finnVirksomheterMedAktivSykmelding(dineSykmeldingerReducer.data, ledereReducer.data);
     const oppfolgingsforlopsPerioderReducerListe = finnOppfolgingsforlopsPerioderForAktiveSykmeldinger(state, virksomhetsnrListe);
@@ -132,7 +147,7 @@ export function mapStateToProps(state) {
         const motebehovSvarReducer = state.motebehovSvar[virksomhetsnr] || {};
         motebehovSvarReducerListe.push(motebehovSvarReducer);
     });
-    const skalViseMotebehov = skalViseMotebehovMedOppfolgingsforlopListe(oppfolgingsforlopsPerioderReducerListe, motebehovReducer);
+    const skalViseMotebehov = skalViseMotebehovMedOppfolgingsforlopListe(oppfolgingsforlopsPerioderReducerListe, motebehovReducer, moteReducer);
 
     const skalHenteLedere = !henterEllerHarHentetLedere(ledereReducer);
     const skalHenteOppfolgingsPerioder = !henterEllerHarForsoektHentetOppfolgingsPerioder([state.oppfolgingsforlopsPerioder]);

--- a/js/sider/MotebehovSide.js
+++ b/js/sider/MotebehovSide.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { getLedetekst, keyValue } from '@navikt/digisyfo-npm';
-import { brodsmule as brodsmulePt, motebehovReducerPt, motebehovSvarReducerPt } from '../propTypes';
+import {
+    brodsmule as brodsmulePt,
+    motebehovReducerPt,
+    motebehovSvarReducerPt,
+} from '../propTypes';
 import Side from './Side';
 import MotebehovInnhold from '../components/moter/MotebehovInnhold';
 import AppSpinner from '../components/AppSpinner';
@@ -76,17 +80,21 @@ class Container extends Component {
                     (() => {
                         if (henter) {
                             return <AppSpinner />;
-                        } else if (hentingFeilet || sendingFeilet) {
+                        } if (hentingFeilet || sendingFeilet) {
                             return <Feilmelding />;
-                        } else if (!skalViseMotebehov) {
-                            return (<Feilmelding
-                                tittel={'Møtebehovsiden er ikke tilgjengelig nå.'}
-                                melding={'Dette kan være fordi veilederen din allerede har forespurt et møte, hvis ikke, prøv igjen senere.'}
-                            />);
+                        } if (!skalViseMotebehov) {
+                            return (
+                                <Feilmelding
+                                    tittel="Møtebehovsiden er ikke tilgjengelig nå."
+                                    melding="Dette kan være fordi veilederen din allerede har forespurt et møte, hvis ikke, prøv igjen senere."
+                                />
+                            );
                         }
-                        return (<MotebehovInnhold
-                            {...this.props}
-                        />);
+                        return (
+                            <MotebehovInnhold
+                                {...this.props}
+                            />
+                        );
                     })()
                 }
             </Side>

--- a/js/utils/motebehovUtils.js
+++ b/js/utils/motebehovUtils.js
@@ -144,15 +144,57 @@ export const finnVirksomhetnrListeMedSkalViseMotebehov = (oppfolgingsforlopsPeri
     return liste;
 };
 
-export const skalViseMotebehovMedOppfolgingsforlopListe = (oppfolgingsforlopsPerioderReducerListe, motebehovReducer) => {
+export const orgnummerFraMote = (moteReducer) => {
+    const moteData = moteReducer.data;
+    const deltakerMedOrgnummer = moteData.deltakere && moteData.deltakere.find((deltaker) => {
+        return !!deltaker.orgnummer;
+    });
+    return deltakerMedOrgnummer.orgnummer;
+};
+
+export const moteOpprettetIOppfolgingstilfelle = (moteReducer, oppfolgingsforlopsPerioderReducerListe) => {
+    const orgnummer = moteReducer && orgnummerFraMote(moteReducer);
+    const oppfolgingsforlopsPerioderReducer = oppfolgingsforlopsPerioderReducerListe.find((periodeReducer) => {
+        return periodeReducer.virksomhetsnummer === orgnummer;
+    });
+
+    const startOppfolgingsdato = oppfolgingsforlopsPerioderReducer.data && hentOppfolgingsforlopStartdato(oppfolgingsforlopsPerioderReducer.data);
+    const sluttOppfolgingsdato = oppfolgingsforlopsPerioderReducer.data && hentOppfolgingsforlopSluttdato(oppfolgingsforlopsPerioderReducer.data);
+    const moteOpprettetDato = new Date(moteReducer.data.opprettetTidspunkt);
+
+    return startOppfolgingsdato <= moteOpprettetDato && moteOpprettetDato <= sluttOppfolgingsdato;
+};
+
+export const moteplanleggerBruktIOppfolgingstilfelle = (moteReducer, oppfolgingsforlopsPerioderReducerListe) => {
+    if (!moteReducer || !moteReducer.data) {
+        return false;
+    }
+
+    return moteOpprettetIOppfolgingstilfelle(moteReducer, oppfolgingsforlopsPerioderReducerListe);
+};
+
+export const harSykmeldtSvartPaaMotebehov = (motebehovReducer) => {
+    return motebehovReducer.data && motebehovReducer.data.findIndex((motebehov) => {
+        return motebehov.aktorId === motebehov.opprettetAv;
+    }) > -1;
+};
+
+export const skalViseMotebehovMedOppfolgingsforlopListe = (oppfolgingsforlopsPerioderReducerListe, motebehovReducer, moteReducer) => {
     try {
         if (motebehovReducer && motebehovReducer.hentingForbudt === true) {
             return false;
         }
+        if (motebehovReducer && harSykmeldtSvartPaaMotebehov(motebehovReducer)) {
+            return true;
+        }
 
-        return oppfolgingsforlopsPerioderReducerListe.filter((oppfolgingsforlopsPerioderReducer) => {
+        const oppfolgingsforlopMedMotebehovVisning = oppfolgingsforlopsPerioderReducerListe.filter((oppfolgingsforlopsPerioderReducer) => {
             return skalViseMotebehovForOppfolgingsforlop(oppfolgingsforlopsPerioderReducer);
-        }).length > 0;
+        });
+        if (oppfolgingsforlopMedMotebehovVisning.length === 0) {
+            return false;
+        }
+        return !moteplanleggerBruktIOppfolgingstilfelle(moteReducer, oppfolgingsforlopsPerioderReducerListe);
     } catch (e) {
         return false;
     }
@@ -162,7 +204,7 @@ export const erMotebehovTilgjengeligForOppfolgingsforlop = (state) => {
     const virksomhetsnrListe = finnVirksomheterMedAktivSykmelding(state.dineSykmeldinger.data, state.ledere.data);
     const oppfolgingsforlopsPerioderReducerListe = finnOppfolgingsforlopsPerioderForAktiveSykmeldinger(state, virksomhetsnrListe);
 
-    return skalViseMotebehovMedOppfolgingsforlopListe(oppfolgingsforlopsPerioderReducerListe, state.motebehov);
+    return skalViseMotebehovMedOppfolgingsforlopListe(oppfolgingsforlopsPerioderReducerListe, state.motebehov, state.mote);
 };
 
 export const harMotebehovSvar = (state) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4989,13 +4989,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5012,19 +5014,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5155,7 +5160,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5169,6 +5175,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5185,6 +5192,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5193,13 +5201,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5220,6 +5230,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5308,7 +5319,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5322,6 +5334,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5459,6 +5472,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5620,7 +5634,6 @@
       "resolved": "https://repo.adeo.no/repository/npm-public/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -6644,8 +6657,7 @@
       "version": "1.0.0",
       "resolved": "https://repo.adeo.no/repository/npm-public/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -6667,7 +6679,6 @@
       "resolved": "https://repo.adeo.no/repository/npm-public/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -12300,7 +12311,6 @@
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12319,7 +12329,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -12413,7 +12422,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -12499,8 +12507,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -12606,8 +12613,7 @@
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4965,8 +4965,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4990,15 +4989,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5015,22 +5012,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5161,8 +5155,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5176,7 +5169,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5193,7 +5185,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5202,15 +5193,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5231,7 +5220,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5320,8 +5308,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5335,7 +5322,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5431,8 +5417,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5474,7 +5459,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5496,7 +5480,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5545,15 +5528,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/test/utils/motebehovUtilsTest.js
+++ b/test/utils/motebehovUtilsTest.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import sinon from 'sinon';
 import {
-    finnNyesteMotebehovForVirksomhetListe,
+    finnNyesteMotebehovForVirksomhetListeIOppfolgingstilfelle,
     skalViseMotebehovKvittering,
     hentMoteLandingssideUrl,
     erOppfolgingstilfelleSluttDatoPassert,
@@ -32,9 +32,10 @@ describe('motebehovUtils', () => {
         clock.restore();
     });
 
-    describe('finnNyesteMotebehovForVirksomhetListe', () => {
+    describe('finnNyesteMotebehovForVirksomhetListeIOppfolgingstilfelle', () => {
         let motebehovReducer;
         let virksomhetsnrListe;
+        let oppfolgingsforlopsPerioderReducerListe;
         beforeEach(() => {
             virksomhetsnrListe = ['110110110', '110110111'];
             motebehovReducer = {
@@ -49,28 +50,62 @@ describe('motebehovUtils', () => {
                     }),
                 ],
             };
+            oppfolgingsforlopsPerioderReducerListe = [
+                {
+                    data: [
+                        {
+                            avventende: null,
+                            behandlingsdager: 0,
+                            fom: leggTilDagerPaaDato(new Date(), -10),
+                            grad: 100,
+                            reisetilskudd: false,
+                            tom: '2019-12-15',
+                        },
+                    ],
+                    virksomhetsnummer: '110110110',
+                },
+                {
+                    data: [
+                        {
+                            avventende: null,
+                            behandlingsdager: 0,
+                            fom: leggTilDagerPaaDato(new Date(), -10),
+                            grad: 100,
+                            reisetilskudd: false,
+                            tom: '2019-12-15',
+                        },
+                    ],
+                    virksomhetsnummer: '110110111',
+                },
+            ];
         });
-        it('Skal finne nyeste motebehov dersom det er flere motebehov hos ulike virksomheter', () => {
+        it('Skal finne nyeste motebehov i et oppfolgingstilfelle dersom det er flere motebehov hos ulike virksomheter', () => {
             const exp = virksomhetsnrListe[1];
-            const res = finnNyesteMotebehovForVirksomhetListe(motebehovReducer, virksomhetsnrListe).virksomhetsnummer;
+            const res = finnNyesteMotebehovForVirksomhetListeIOppfolgingstilfelle(motebehovReducer, virksomhetsnrListe, oppfolgingsforlopsPerioderReducerListe).virksomhetsnummer;
             expect(res).to.equal(exp);
         });
 
-        it('Skal finne nyeste motebehov dersom det er flere motebehov hos en virksomhet', () => {
+        it('Skal finne nyeste motebehov i et oppfolgingstilfelle dersom det er flere motebehov hos en virksomhet', () => {
             const exp = virksomhetsnrListe[0];
-            const res = finnNyesteMotebehovForVirksomhetListe(motebehovReducer, [virksomhetsnrListe[0]]).virksomhetsnummer;
+            const res = finnNyesteMotebehovForVirksomhetListeIOppfolgingstilfelle(motebehovReducer, [virksomhetsnrListe[0]], oppfolgingsforlopsPerioderReducerListe).virksomhetsnummer; // eslint-disable-line max-len
             expect(res).to.equal(exp);
         });
 
         it('Skal ikke finne nyeste motebehov dersom det er motebehov, men ikke hos viksomhet', () => {
             const exp = undefined;
-            const res = finnNyesteMotebehovForVirksomhetListe(motebehovReducer, []);
+            const res = finnNyesteMotebehovForVirksomhetListeIOppfolgingstilfelle(motebehovReducer, [], oppfolgingsforlopsPerioderReducerListe);
             expect(res).to.equal(exp);
         });
 
         it('Skal ikke finne nyeste motebehov dersom det ikke er motebehov hos virksomhet', () => {
             const exp = undefined;
-            const res = finnNyesteMotebehovForVirksomhetListe({ data: [] }, virksomhetsnrListe);
+            const res = finnNyesteMotebehovForVirksomhetListeIOppfolgingstilfelle({ data: [] }, virksomhetsnrListe, oppfolgingsforlopsPerioderReducerListe);
+            expect(res).to.equal(exp);
+        });
+
+        it('Skal ikke finne nyeste motebehov dersom det er motebehov, men ingen i et gjeldende oppfolgingstilfelle', () => {
+            const exp = undefined;
+            const res = finnNyesteMotebehovForVirksomhetListeIOppfolgingstilfelle(motebehovReducer, virksomhetsnrListe, []);
             expect(res).to.equal(exp);
         });
     });
@@ -78,6 +113,7 @@ describe('motebehovUtils', () => {
     describe('skalViseMotebehovKvittering', () => {
         let motebehovReducer;
         let virksomhetsnrListe;
+        let oppfolgingsforlopsPerioderReducerListe;
         beforeEach(() => {
             virksomhetsnrListe = ['110110110', '110110111'];
             motebehovReducer = {
@@ -92,22 +128,56 @@ describe('motebehovUtils', () => {
                     }),
                 ],
             };
+            oppfolgingsforlopsPerioderReducerListe = [
+                {
+                    data: [
+                        {
+                            avventende: null,
+                            behandlingsdager: 0,
+                            fom: leggTilDagerPaaDato(new Date(), -10),
+                            grad: 100,
+                            reisetilskudd: false,
+                            tom: '2019-12-15',
+                        },
+                    ],
+                    virksomhetsnummer: '110110110',
+                },
+                {
+                    data: [
+                        {
+                            avventende: null,
+                            behandlingsdager: 0,
+                            fom: leggTilDagerPaaDato(new Date(), -10),
+                            grad: 100,
+                            reisetilskudd: false,
+                            tom: '2019-12-15',
+                        },
+                    ],
+                    virksomhetsnummer: '110110111',
+                },
+            ];
         });
-        it('Skal returnere false om det ikke eksisterer motebehov hos virksomhet', () => {
+        it('Skal returnere false om det ikke eksisterer motebehov hos virksomhet i et oppfolgingstilfelle', () => {
             const exp = false;
-            const res = skalViseMotebehovKvittering({ data: [] }, virksomhetsnrListe);
+            const res = skalViseMotebehovKvittering({ data: [] }, virksomhetsnrListe, oppfolgingsforlopsPerioderReducerListe);
             expect(res).to.equal(exp);
         });
 
-        it('Skal returnere false om det eksisterer motebehov, men ikke hos virksomhet', () => {
+        it('Skal returnere false om det eksisterer motebehov i et oppfolgingstilfelle, men ikke hos virksomhet', () => {
             const exp = false;
-            const res = skalViseMotebehovKvittering({ data: [] }, virksomhetsnrListe);
+            const res = skalViseMotebehovKvittering({ data: [] }, virksomhetsnrListe, oppfolgingsforlopsPerioderReducerListe);
             expect(res).to.equal(exp);
         });
 
-        it('Skal returnere true om det eksisterer motebehov hos virksomhet', () => {
+        it('Skal returnere true om det eksisterer motebehov hos virksomhet i et oppfolgingstilfelle', () => {
             const exp = true;
-            const res = skalViseMotebehovKvittering(motebehovReducer, virksomhetsnrListe);
+            const res = skalViseMotebehovKvittering(motebehovReducer, virksomhetsnrListe, oppfolgingsforlopsPerioderReducerListe);
+            expect(res).to.equal(exp);
+        });
+
+        it('Skal returnere false om det eksisterer motebehov hos virksomhet, men ikke i et oppfolgingstilfelle', () => {
+            const exp = false;
+            const res = skalViseMotebehovKvittering(motebehovReducer, virksomhetsnrListe, []);
             expect(res).to.equal(exp);
         });
     });
@@ -280,15 +350,16 @@ describe('motebehovUtils', () => {
             expect(skalViseMotebehovMedOppfolgingsforlopListe([oppfolgingsforlopsPerioderReducer])).to.equal(false);
         });
 
-        it('skal returnere true, dersom bruker allerede har svart på møtebehov', () => {
+        it('skal returnere true, dersom bruker allerede har svart på møtebehov innen et oppfolgingstilfelle', () => {
             oppfolgingsforlopsPerioderReducer = {
                 data: [
-                    { fom: leggTilDagerPaaDato(new Date(), -OPPFOLGINGSFORLOP_MOTEBEHOV_SLUTT_DAGER) },
+                    { fom: leggTilDagerPaaDato(new Date(), -OPPFOLGINGSFORLOP_MOTEBEHOV_START_DAGER) },
                 ],
             };
             motebehovReducer = {
                 data: [
                     {
+                        opprettetDato: leggTilDagerPaaDato(new Date(), -(OPPFOLGINGSFORLOP_MOTEBEHOV_START_DAGER - 1)),
                         aktorId: '000111222333',
                         opprettetAv: '000111222333',
                     },

--- a/test/utils/motebehovUtilsTest.js
+++ b/test/utils/motebehovUtilsTest.js
@@ -237,8 +237,11 @@ describe('motebehovUtils', () => {
     describe('skalViseMotebehovMedOppfolgingsforlopListe', () => {
         let oppfolgingsforlopsPerioderReducer;
         let motebehovReducer;
+        let moteReducer;
         beforeEach(() => {
             oppfolgingsforlopsPerioderReducer = {};
+            motebehovReducer = {};
+            moteReducer = {};
         });
 
         it('skal returnere false, dersom oppfolgingsdato ikke er passert med 16uker', () => {
@@ -277,6 +280,23 @@ describe('motebehovUtils', () => {
             expect(skalViseMotebehovMedOppfolgingsforlopListe([oppfolgingsforlopsPerioderReducer])).to.equal(false);
         });
 
+        it('skal returnere true, dersom bruker allerede har svart på møtebehov', () => {
+            oppfolgingsforlopsPerioderReducer = {
+                data: [
+                    { fom: leggTilDagerPaaDato(new Date(), -OPPFOLGINGSFORLOP_MOTEBEHOV_SLUTT_DAGER) },
+                ],
+            };
+            motebehovReducer = {
+                data: [
+                    {
+                        aktorId: '000111222333',
+                        opprettetAv: '000111222333',
+                    },
+                ],
+            };
+            expect(skalViseMotebehovMedOppfolgingsforlopListe([oppfolgingsforlopsPerioderReducer], motebehovReducer)).to.equal(true);
+        });
+
         describe('hentingForbudt', () => {
             it('skal returnere false, henting av motebehov er forbudt fra syfomotebehov', () => {
                 oppfolgingsforlopsPerioderReducer = {
@@ -288,6 +308,54 @@ describe('motebehovUtils', () => {
                     hentingForbudt: true,
                 };
                 expect(skalViseMotebehovMedOppfolgingsforlopListe([oppfolgingsforlopsPerioderReducer], motebehovReducer)).to.equal(false);
+            });
+        });
+
+        describe('moteplanleggerBrukt', () => {
+            it('skal returnere false, dersom møteplanleggeren er brukt i oppfølgingstilfellet', () => {
+                oppfolgingsforlopsPerioderReducer = {
+                    virksomhetsnummer: '555666444',
+                    data: [
+                        {
+                            fom: leggTilDagerPaaDato(new Date(), -(OPPFOLGINGSFORLOP_MOTEBEHOV_SLUTT_DAGER - 1)),
+                            tom: new Date(),
+                        },
+                    ],
+                };
+                moteReducer = {
+                    data: {
+                        opprettetTidspunkt: leggTilDagerPaaDato(new Date(), -(OPPFOLGINGSFORLOP_MOTEBEHOV_SLUTT_DAGER - 5)),
+                        deltakere: [
+                            {
+                                orgnummer: '555666444',
+                            },
+                        ],
+                    },
+                };
+                expect(skalViseMotebehovMedOppfolgingsforlopListe([oppfolgingsforlopsPerioderReducer], motebehovReducer, moteReducer)).to.equal(false);
+            });
+
+            it('skal returnere true, dersom møteplanleggeren er brukt før oppfølgingstilfellet', () => {
+                oppfolgingsforlopsPerioderReducer = {
+                    virksomhetsnummer: '555666444',
+                    data: [
+                        {
+                            fom: leggTilDagerPaaDato(new Date(), -(OPPFOLGINGSFORLOP_MOTEBEHOV_SLUTT_DAGER - 1)),
+                            tom: new Date(),
+                        },
+                    ],
+                };
+                moteReducer = {
+                    data: {
+                        opprettetTidspunkt: leggTilDagerPaaDato(new Date(), -(OPPFOLGINGSFORLOP_MOTEBEHOV_SLUTT_DAGER + 5)),
+                        deltakere: [
+                            {
+                                orgnummer: '555666444',
+                            },
+                        ],
+                    },
+                };
+                expect(skalViseMotebehovMedOppfolgingsforlopListe([oppfolgingsforlopsPerioderReducer], motebehovReducer, moteReducer)).to.equal(true);
             });
         });
     });


### PR DESCRIPTION
Hvis møteplanleggeren ikke er brukt, vis møtebehovskjema som vanlig.
Hvis møteplanleggeren er brukt, selv om forespørselen er avbrutt eller bekreftet, ikke vis møtebehovskjema.
Hvis møteplanleggeren er brukt, selv om forespørselen er avbrutt eller bekreftet, vis møtebehovkvittering hvis sykmeldt allerede har svart.
Hvis sykmeldt har begynt på nytt syketilfelle, eller siste dato i tilfellet er passert, ikke vis møtebehovsiden i det hele tatt.
Vis feilmelding hvis brukeren går inn på møtebehovsiden uten at den er tilgjengelig.