### PR TITLE
Bruker syfosmregisterproxy i stedet for syfoapi

### DIFF
--- a/mock/mockSmSykmeldinger.js
+++ b/mock/mockSmSykmeldinger.js
@@ -2,7 +2,7 @@ const mockData = require('./mockData');
 const enums = require('./mockDataEnums');
 
 function mockHentSykmeldinger(server) {
-    server.get('/syfosmregister/api/v1/sykmeldinger', (req, res) => {
+    server.get('/syfosmregister/v1/sykmeldinger', (req, res) => {
         res.setHeader('Content-Type', 'application/json');
         res.send(JSON.stringify(mockData[enums.SM_SYKMELDINGER]));
     });
@@ -11,7 +11,7 @@ function mockHentSykmeldinger(server) {
 function mockSmSykmeldingerLokalt(server) {
     mockHentSykmeldinger(server);
 
-    server.post('/syfosmregister/api/v1/sykmeldinger/:id/bekreft', (req, res) => {
+    server.post('/syfosmregister/v1/sykmeldinger/:id/bekreft', (req, res) => {
         res.status(200);
         setTimeout(() => {
             res.send('');


### PR DESCRIPTION
Cookie problemene i syfoproxy er løst og CORS er håndtert, nå fungerer det som bare det.

Det viste seg at proxying i express-appen var litt stress og lite gjennomsiktig. Det er ikke optimalt å ha egne proxyapper for alle apper, men det er ikke sykt kult å dra hele dette problemet inn i frontendappen heller. Den har det vondt nok fra før...