### PR TITLE
henter sykmeldinger via nginx-proxy

### DIFF
--- a/mock/mockSmSykmeldinger.js
+++ b/mock/mockSmSykmeldinger.js
@@ -2,7 +2,7 @@ const mockData = require('./mockData');
 const enums = require('./mockDataEnums');
 
 function mockHentSykmeldinger(server) {
-    server.get('/syfosmregister/api/v1/sykmeldinger', (req, res) => {
+    server.get('/syfosmregister/v1/sykmeldinger', (req, res) => {
         res.setHeader('Content-Type', 'application/json');
         res.send(JSON.stringify(mockData[enums.SM_SYKMELDINGER]));
     });
@@ -11,7 +11,7 @@ function mockHentSykmeldinger(server) {
 function mockSmSykmeldingerLokalt(server) {
     mockHentSykmeldinger(server);
 
-    server.post('/syfosmregister/api/v1/sykmeldinger/:id/bekreft', (req, res) => {
+    server.post('/syfosmregister/v1/sykmeldinger/:id/bekreft', (req, res) => {
         res.status(200);
         setTimeout(() => {
             res.send('');


### PR DESCRIPTION
Vi forsøker å hente sykmeldingene via nginx-proxyen igjen for å se om det går bedre denne gangen. Jeg har gjeninnført endringene som ble rullet tilbake her: https://github.com/navikt/sykefravaer/pull/268/files

For å fange opp mulige problemer vil vi følge med i hotjar, og jeg kommer til å lage en PR der denne endringen er rullet tilbake så fort denne er merget slik at vi raskt kan rulle tilbake. 

Det er viktig at denne PR-en ikke merges før vi er klare til å følge med på hvordan det går! :) 