### PR TITLE
Oppdaterer URL til veientilarbeid

### DIFF
--- a/js/arbeidsrettet-oppfolging/HarAlleredeOppfolgingAlertstripe.js
+++ b/js/arbeidsrettet-oppfolging/HarAlleredeOppfolgingAlertstripe.js
@@ -8,7 +8,7 @@ const HarAlleredeOppfolgingAlertstripe = () => {
         <Alertstripe type="suksess" className="alleredeOppfolging blokk">
             <div className="alleredeOppfolging__innhold">
                 <Normaltekst className="alleredeOppfolging__tekst">{getLedetekst('infoside-fo.alertstripe.tekst')}</Normaltekst>
-                <a className="lenke" href="/veientilarbeid">
+                <a className="lenke" href="https://veientilarbeid.nav.no">
                     {getLedetekst('infoside-fo.alertstripe.knapp-tekst')}
                 </a>
             </div>

--- a/js/arbeidsrettet-oppfolging/HarAlleredeOppfolgingAlertstripe.js
+++ b/js/arbeidsrettet-oppfolging/HarAlleredeOppfolgingAlertstripe.js
@@ -4,11 +4,14 @@ import { getLedetekst } from '@navikt/digisyfo-npm';
 import React from 'react';
 
 const HarAlleredeOppfolgingAlertstripe = () => {
+    const urlVeientilarbeid = process.env.NAIS_CLUSTER_NAME === 'dev-sbs'
+        ? 'https://veientilarbeid-q.nav.no'
+        : 'https://veientilarbeid.nav.no';
     return (
         <Alertstripe type="suksess" className="alleredeOppfolging blokk">
             <div className="alleredeOppfolging__innhold">
                 <Normaltekst className="alleredeOppfolging__tekst">{getLedetekst('infoside-fo.alertstripe.tekst')}</Normaltekst>
-                <a className="lenke" href="https://veientilarbeid.nav.no">
+                <a className="lenke" href={urlVeientilarbeid}>
                     {getLedetekst('infoside-fo.alertstripe.knapp-tekst')}
                 </a>
             </div>


### PR DESCRIPTION
Ref. https://nav-it.slack.com/archives/CMA3XV997/p1579608022009400.

Enkelt forslag til oppdatering av URL inn til arbeidssøkerdomenet v/ Veien til Arbeid. Denne endringen hensyntar ikke preprod-miljøer. Går det greit?