### PR TITLE
Remove toggle in Tidslinje

### DIFF
--- a/js/data/unleash-toggles/unleashTogglesSelectors.js
+++ b/js/data/unleash-toggles/unleashTogglesSelectors.js
@@ -11,7 +11,6 @@ export const toggleSelvstendigSoknad = (state) => {
 
 import {
     AKTIVITETSKRAV_INFORMASJON,
-    DIALOGMOTE2_INFORMASJON,
     SYKMELDING_ARBEIDSSITUASJON,
     NY_ARBEIDSTAKERSOKNAD,
     NYTT_SYKMELDINGSMOTTAK,
@@ -45,9 +44,4 @@ export const toggleBrukNginxProxy = (state) => {
 export const skalViseAktivitetskravInformasjon = (state) => {
     return !state.unleashToggles.hentingFeilet
         && state.unleashToggles.data[AKTIVITETSKRAV_INFORMASJON] === true;
-};
-
-export const skalViseDialogmote2Informasjon = (state) => {
-    return !state.unleashToggles.hentingFeilet
-        && state.unleashToggles.data[DIALOGMOTE2_INFORMASJON] === true;
 };

--- a/js/enums/unleashToggles.js
+++ b/js/enums/unleashToggles.js
@@ -10,4 +10,3 @@ export const NY_ARBEIDSTAKERSOKNAD = 'syfo.ag.soknad.ny.platform';
 export const NYTT_SYKMELDINGSMOTTAK = 'syfo.syfofront.nytt.sykmeldingsmottak';
 export const NGINX_PROXY = 'syfo.syfofront.nginx';
 export const AKTIVITETSKRAV_INFORMASJON = 'syfo.informasjon.aktivitetskrav';
-export const DIALOGMOTE2_INFORMASJON = 'syfo.informasjon.dialogmote';

--- a/js/landingsside/tidslinje-utdrag/TidslinjeUtdrag.js
+++ b/js/landingsside/tidslinje-utdrag/TidslinjeUtdrag.js
@@ -116,15 +116,8 @@ export const VelgArbeidssituasjon = (props) => {
     );
 };
 
-const skalIkkeViseUtdrag = (antallDager, tekstObjekt, skalViseAktivitetskrav) => {
-    const aktivitetskravNokkelMedAG = 'tidslinje.utdrag.aktivitetskrav-med-arbeidsgiver';
-    const aktivitetskravNokkelUtenAG = 'tidslinje.utdrag.mulighet-for-aktivitet-uten-arbeidsgiver';
-
-    if (antallDager > 500 || !tekstObjekt || (!skalViseAktivitetskrav
-        && (tekstObjekt.nokkel === aktivitetskravNokkelMedAG || tekstObjekt.nokkel === aktivitetskravNokkelUtenAG))) {
-        return true;
-    }
-    return false;
+const skalIkkeViseUtdrag = (antallDager, tekstObjekt) => {
+    return antallDager > 500 || !tekstObjekt;
 };
 
 const track = (event) => {
@@ -206,9 +199,9 @@ export default class TidslinjeUtdrag extends Utvidbar {
     }
 
     render() {
-        const { visning, antallDager, skalViseAktivitetskrav } = this.props;
+        const { visning, antallDager } = this.props;
         const tekstObjekt = this.getTekstObjekt();
-        if (skalIkkeViseUtdrag(antallDager, tekstObjekt, skalViseAktivitetskrav)) {
+        if (skalIkkeViseUtdrag(antallDager, tekstObjekt)) {
             return null;
         }
         const nokkelbase = this.getNokkelbase();

--- a/js/landingsside/tidslinje-utdrag/TidslinjeutdragContainer.js
+++ b/js/landingsside/tidslinje-utdrag/TidslinjeutdragContainer.js
@@ -3,7 +3,6 @@ import { senesteTom, sykmeldingstatuser, arbeidssituasjoner } from '@navikt/digi
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import TidslinjeUtdrag, { MED_ARBEIDSGIVER, UTEN_ARBEIDSGIVER, VALGFRI } from './TidslinjeUtdrag';
-import { skalViseAktivitetskravInformasjon } from '../../data/unleash-toggles/unleashTogglesSelectors';
 
 const {
     SENDT, NY, BEKREFTET, TIL_SENDING,
@@ -14,7 +13,7 @@ const TRETTINI_UKER = 7 * 39;
 
 export const Container = (props) => {
     const {
-        visUtdrag, startdato, antallDager, visning, hentingFeilet, skalViseAktivitetskrav,
+        visUtdrag, startdato, antallDager, visning, hentingFeilet,
     } = props;
     return (!visUtdrag || hentingFeilet)
         ? null
@@ -23,7 +22,7 @@ export const Container = (props) => {
                 startdato={startdato}
                 antallDager={antallDager}
                 visning={visning}
-                skalViseAktivitetskrav={skalViseAktivitetskrav} />
+            />
         );
 };
 
@@ -33,7 +32,6 @@ Container.propTypes = {
     antallDager: PropTypes.number,
     visning: PropTypes.oneOf([MED_ARBEIDSGIVER, UTEN_ARBEIDSGIVER, VALGFRI]),
     hentingFeilet: PropTypes.bool,
-    skalViseAktivitetskrav: PropTypes.bool,
 };
 
 export const getSykefravaerVarighet = (state) => {
@@ -125,7 +123,6 @@ export const mapStateToProps = (state) => {
         antallDager,
         visUtdrag: skalViseUtdrag(state),
         visning: getVisning(state),
-        skalViseAktivitetskrav: skalViseAktivitetskravInformasjon(state),
     };
 };
 

--- a/js/sider/TidslinjeSide.js
+++ b/js/sider/TidslinjeSide.js
@@ -19,10 +19,6 @@ import {
     sykeforloepPt,
 } from '../propTypes';
 import Tidslinje from '../tidslinje/Tidslinje';
-import {
-    skalViseAktivitetskravInformasjon,
-    skalViseDialogmote2Informasjon,
-} from '../data/unleash-toggles/unleashTogglesSelectors';
 
 export class Container extends Component {
     constructor(props) {
@@ -57,7 +53,7 @@ export class Container extends Component {
 
     render() {
         const {
-            brodsmuler, hendelser, arbeidssituasjon, henter, hentingFeilet, visAktivitetskravInformasjon, visDialogmote2Informasjon,
+            brodsmuler, hendelser, arbeidssituasjon, henter, hentingFeilet,
         } = this.props;
         const htmlIntro = {
             __html: `<p>${getLedetekst('tidslinje.introtekst')}</p>`,
@@ -84,8 +80,6 @@ export class Container extends Component {
                                     hendelser={hendelser}
                                     arbeidssituasjon={arbeidssituasjon}
                                     setHendelseData={this.setHendelseData}
-                                    visAktivitetskravInformasjon={visAktivitetskravInformasjon}
-                                    visDialogmote2Informasjon={visDialogmote2Informasjon}
                                 />
                             </div>
                         );
@@ -107,8 +101,6 @@ Container.propTypes = {
     doHentSykeforloep: PropTypes.func,
     doHentTidslinjer: PropTypes.func,
     doSetHendelseData: PropTypes.func,
-    visAktivitetskravInformasjon: PropTypes.bool,
-    visDialogmote2Informasjon: PropTypes.bool,
 };
 
 export const mapArbeidssituasjonParam = (param) => {
@@ -151,8 +143,6 @@ export function mapStateToProps(state, ownProps) {
     }
     const apneHendelseIder = (ownProps && ownProps.location) ? ownProps.location.hash.replace('#', '').split('/') : [];
 
-    const visAktivitetskravInformasjon = skalViseAktivitetskravInformasjon(state);
-    const visDialogmote2Informasjon = skalViseDialogmote2Informasjon(state);
     return {
         arbeidssituasjon,
         hendelser,
@@ -162,8 +152,6 @@ export function mapStateToProps(state, ownProps) {
         sykeforloep: state.sykeforloep,
         hentingFeilet: state.ledetekster.hentingFeilet
         || state.sykeforloep.hentingFeilet,
-        visAktivitetskravInformasjon,
-        visDialogmote2Informasjon,
         brodsmuler: [{
             tittel: getLedetekst('landingsside.sidetittel'),
             sti: '/',

--- a/js/tidslinje/Tidslinje.js
+++ b/js/tidslinje/Tidslinje.js
@@ -5,13 +5,7 @@ import HendelseTittel from './HendelseTittel';
 import HendelseBoble from './HendelseBoble';
 import { tidslinjehendelse as hendelsePt } from './tidslinjePropTypes';
 
-const filterToggles = (antallDager, visAktivitetskravInformasjon, visDialogmote2Informasjon) => {
-    const erHendelseAktivitetsKravInformasjon = antallDager === 49 || antallDager === 55;
-    const erHendelseDialogmoteInformasjon = antallDager === 119 || antallDager === 181;
-    return !((erHendelseAktivitetsKravInformasjon && visAktivitetskravInformasjon === false) || (erHendelseDialogmoteInformasjon && visDialogmote2Informasjon === false));
-};
-
-const Tidslinje = ({ hendelser = [], ledetekster, arbeidssituasjon, setHendelseData, visAktivitetskravInformasjon, visDialogmote2Informasjon }) => {
+const Tidslinje = ({ hendelser = [], ledetekster, arbeidssituasjon, setHendelseData }) => {
     const nyNaermesteLederHendelseMedArbeidsgiver = (hendelse) => {
         return !(arbeidssituasjon === 'UTEN_ARBEIDSGIVER' && hendelse.type === 'NY_NAERMESTE_LEDER');
     };
@@ -20,7 +14,6 @@ const Tidslinje = ({ hendelser = [], ledetekster, arbeidssituasjon, setHendelseD
             {
                 hendelser
                     .filter(nyNaermesteLederHendelseMedArbeidsgiver)
-                    .filter((hendelse) => { return filterToggles(hendelse.antallDager, visAktivitetskravInformasjon, visDialogmote2Informasjon); })
                     .filter((h) => {
                         return h.type !== 'AKTIVITETSKRAV_VARSEL';
                     })
@@ -55,8 +48,6 @@ Tidslinje.propTypes = {
     ledetekster: keyValue,
     arbeidssituasjon: PropTypes.string,
     setHendelseData: PropTypes.func,
-    visAktivitetskravInformasjon: PropTypes.bool,
-    visDialogmote2Informasjon: PropTypes.bool,
 };
 
 export default Tidslinje;


### PR DESCRIPTION
Remove toggle for information about Aktivitetskrav and Dialogmote2 in Tidslinje. Det situation is back to normal and the information is therefore turned on.