### PR TITLE
log any the referer of any initial loads to /sykefravaer/sykmeldinger

### DIFF
--- a/server.js
+++ b/server.js
@@ -30,6 +30,15 @@ const server = express();
 const env = process.argv[2];
 const settings = env === 'local' ? { isProd: false } : require('./settings.json');
 
+// Logg alle innkommende lenker til gammel sykmeldinger del av appen
+server.use((req, res, next) => {
+    if (req.path.includes('/sykefravaer/sykmeldinger')) {
+        console.warn(`Innkommende lenke fra referer: ${req.headers.referer || 'Ikke satt'}`);
+    }
+
+    next();
+});
+
 server.set('views', `${__dirname}/dist`);
 server.set('view engine', 'mustache');
 server.engine('html', mustacheExpress());


### PR DESCRIPTION
Om folk kommer fra bokmerker burde `referer` ikke være satt, men skulle det være noen apps rundt om kring i NAV som linker til feil URL, så kan vi plukke opp på det og kjefte på dem.